### PR TITLE
internal: Error out if resource is not found after resource creation or update

### DIFF
--- a/internal/auth/resource_group.go
+++ b/internal/auth/resource_group.go
@@ -137,7 +137,7 @@ func (r AuthGroupResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	diags := r.SyncState(ctx, &resp.State, server, plan)
+	diags := r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -155,7 +155,7 @@ func (r AuthGroupResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	diags := r.SyncState(ctx, &resp.State, server, state)
+	diags := r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -200,7 +200,7 @@ func (r AuthGroupResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	diags := r.SyncState(ctx, &resp.State, server, plan)
+	diags := r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -226,13 +226,13 @@ func (r AuthGroupResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 }
 
-func (r AuthGroupResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m AuthGroupModel) diag.Diagnostics {
+func (r AuthGroupResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m AuthGroupModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	authGroupName := m.Name.ValueString()
 	authGroup, _, err := server.GetAuthGroup(authGroupName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/auth/resource_identity.go
+++ b/internal/auth/resource_identity.go
@@ -161,7 +161,7 @@ func (r AuthIdentityResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	diags := r.SyncState(ctx, &resp.State, server, plan)
+	diags := r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -179,7 +179,7 @@ func (r AuthIdentityResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	diags := r.SyncState(ctx, &resp.State, server, state)
+	diags := r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -227,7 +227,7 @@ func (r AuthIdentityResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	diags := r.SyncState(ctx, &resp.State, server, plan)
+	diags := r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -255,7 +255,7 @@ func (r AuthIdentityResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 }
 
-func (r AuthIdentityResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m AuthIdentityModel) diag.Diagnostics {
+func (r AuthIdentityResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m AuthIdentityModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	identityName := m.Name.ValueString()
@@ -263,7 +263,7 @@ func (r AuthIdentityResource) SyncState(ctx context.Context, tfState *tfsdk.Stat
 
 	identity, _, err := server.GetIdentity(identityAuthMethod, identityName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/image/resource_image.go
+++ b/internal/image/resource_image.go
@@ -269,7 +269,7 @@ func (r ImageResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -349,7 +349,7 @@ func (r ImageResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	plan.Fingerprint = types.StringValue(imageFingerprint)
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -385,14 +385,14 @@ func (r ImageResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 // SyncState fetches the server's current state for an image and updates the provided model.
 // It then applies this updated model as the new state in Terraform.
-func (r ImageResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m ImageModel) diag.Diagnostics {
+func (r ImageResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m ImageModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	_, imageFingerprint := splitImageResourceID(m.ResourceID.ValueString())
 
 	image, _, err := server.GetImage(imageFingerprint)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}
@@ -597,7 +597,7 @@ func (r ImageResource) createImageFromSourceImage(ctx context.Context, resp *res
 	plan.CopiedAliases = copiedAliases
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, *plan)
+	diags = r.SyncState(ctx, &resp.State, server, *plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -702,7 +702,7 @@ func (r ImageResource) createImageFromSourceInstance(ctx context.Context, resp *
 	plan.CopiedAliases = types.SetValueMust(types.StringType, []attr.Value{})
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, *plan)
+	diags = r.SyncState(ctx, &resp.State, server, *plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -871,7 +871,7 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -902,7 +902,7 @@ func (r InstanceResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -1196,7 +1196,7 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -1278,13 +1278,13 @@ func (r *InstanceResource) ImportState(ctx context.Context, req resource.ImportS
 // SyncState fetches the server's current state for an instance and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m InstanceModel) diag.Diagnostics {
+func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m InstanceModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	instanceName := m.Name.ValueString()
 	instance, _, err := server.GetInstance(instanceName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/instance/resource_instance_device.go
+++ b/internal/instance/resource_instance_device.go
@@ -212,7 +212,7 @@ func (r InstanceDeviceResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Sync state after successfully attaching the device.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -234,7 +234,7 @@ func (r InstanceDeviceResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -311,7 +311,7 @@ func (r InstanceDeviceResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	// Sync state after successfully updating the device properties.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -370,20 +370,20 @@ func (r InstanceDeviceResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	// Sync state after successfully removing the device.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
 // SyncState fetches the server's current state for the device and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r InstanceDeviceResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m InstanceDeviceModel) diag.Diagnostics {
+func (r InstanceDeviceResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m InstanceDeviceModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	instanceName := m.InstanceName.ValueString()
 	instance, _, err := server.GetInstance(instanceName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}
@@ -395,8 +395,13 @@ func (r InstanceDeviceResource) SyncState(ctx context.Context, tfState *tfsdk.St
 	deviceName := m.Name.ValueString()
 	deviceProps, ok := instance.Devices[deviceName]
 	if !ok || deviceProps == nil {
-		tfState.RemoveResource(ctx)
-		return nil
+		if forgetOnNotFound {
+			tfState.RemoveResource(ctx)
+			return nil
+		}
+
+		respDiags.AddError(fmt.Sprintf("Failed to retrieve device %q for instance %q", deviceName, instanceName), "Device not found")
+		return respDiags
 	}
 
 	deviceType, ok := deviceProps["type"]

--- a/internal/instance/resource_instance_snapshot.go
+++ b/internal/instance/resource_instance_snapshot.go
@@ -183,7 +183,7 @@ func (r InstanceSnapshotResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -206,7 +206,7 @@ func (r InstanceSnapshotResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -247,12 +247,12 @@ func (r InstanceSnapshotResource) Delete(ctx context.Context, req resource.Delet
 // SyncState fetches the server's current state for an instance snapshot and
 // updates the provided model. It then applies this updated model as the new
 // state in Terraform.
-func (r InstanceSnapshotResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m InstanceSnapshotModel) diag.Diagnostics {
+func (r InstanceSnapshotResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m InstanceSnapshotModel, forgetOnNotFound bool) diag.Diagnostics {
 	instanceName := m.Instance.ValueString()
 	snapshotName := m.Name.ValueString()
 	snapshot, _, err := server.GetInstanceSnapshot(instanceName, snapshotName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -324,7 +324,7 @@ func (r NetworkResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -346,7 +346,7 @@ func (r NetworkResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -435,7 +435,7 @@ func (r NetworkResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Update Terraform state.
-	diags := r.SyncState(ctx, &resp.State, server, plan)
+	diags := r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -497,13 +497,13 @@ func (r NetworkResource) ImportState(ctx context.Context, req resource.ImportSta
 // SyncState fetches the server's current state for a network and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r NetworkResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkModel) diag.Diagnostics {
+func (r NetworkResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	networkName := m.Name.ValueString()
 	network, _, err := server.GetNetwork(networkName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/network/resource_network_acl.go
+++ b/internal/network/resource_network_acl.go
@@ -258,7 +258,7 @@ func (r *NetworkAclResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -279,7 +279,7 @@ func (r *NetworkAclResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -337,7 +337,7 @@ func (r *NetworkAclResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -387,11 +387,11 @@ func (r *NetworkAclResource) ImportState(ctx context.Context, req resource.Impor
 	}
 }
 
-func (r *NetworkAclResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkAclModel) diag.Diagnostics {
+func (r *NetworkAclResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkAclModel, forgetOnNotFound bool) diag.Diagnostics {
 	aclName := m.Name.ValueString()
 	acl, _, err := server.GetNetworkACL(aclName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/network/resource_network_forward.go
+++ b/internal/network/resource_network_forward.go
@@ -221,7 +221,7 @@ func (r *NetworkForwardResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -242,7 +242,7 @@ func (r *NetworkForwardResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -297,7 +297,7 @@ func (r *NetworkForwardResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -348,12 +348,12 @@ func (r *NetworkForwardResource) ImportState(ctx context.Context, req resource.I
 	}
 }
 
-func (r *NetworkForwardResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkForwardModel) diag.Diagnostics {
+func (r *NetworkForwardResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkForwardModel, forgetOnNotFound bool) diag.Diagnostics {
 	networkName := m.Network.ValueString()
 	listenAddress := m.ListenAddress.ValueString()
 	networkForward, _, err := server.GetNetworkForward(networkName, listenAddress)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/network/resource_network_lb.go
+++ b/internal/network/resource_network_lb.go
@@ -250,7 +250,7 @@ func (r LxdNetworkLBResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -272,7 +272,7 @@ func (r LxdNetworkLBResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -335,7 +335,7 @@ func (r LxdNetworkLBResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -373,14 +373,14 @@ func (r LxdNetworkLBResource) Delete(ctx context.Context, req resource.DeleteReq
 // SyncState fetches the server's current state for an network load balancer
 // and updates the provided model. It then applies this updated model as the
 // new state in Terraform.
-func (r LxdNetworkLBResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkLBModel) diag.Diagnostics {
+func (r LxdNetworkLBResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkLBModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	networkName := m.Network.ValueString()
 	listenAddr := m.ListenAddress.ValueString()
 	lb, _, err := server.GetNetworkLoadBalancer(networkName, listenAddr)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/network/resource_network_peer.go
+++ b/internal/network/resource_network_peer.go
@@ -207,7 +207,7 @@ func (r NetworkPeerResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -229,7 +229,7 @@ func (r NetworkPeerResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -284,7 +284,7 @@ func (r NetworkPeerResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -336,7 +336,7 @@ func (r NetworkPeerResource) Delete(ctx context.Context, req resource.DeleteRequ
 // SyncState fetches the server's current state for a network peer and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r NetworkPeerResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkPeerModel) diag.Diagnostics {
+func (r NetworkPeerResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkPeerModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	peerName := m.Name.ValueString()
@@ -344,7 +344,7 @@ func (r NetworkPeerResource) SyncState(ctx context.Context, tfState *tfsdk.State
 	srcNetwork := m.SourceNetwork.ValueString()
 	peer, _, err := server.GetNetworkPeer(srcNetwork, peerName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/network/resource_network_zone.go
+++ b/internal/network/resource_network_zone.go
@@ -153,7 +153,7 @@ func (r NetworkZoneResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -175,7 +175,7 @@ func (r NetworkZoneResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -227,7 +227,7 @@ func (r NetworkZoneResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -283,11 +283,11 @@ func (r NetworkZoneResource) ImportState(ctx context.Context, req resource.Impor
 // SyncState fetches the server's current state for a network zone and
 // updates the provided model. It then applies this updated model as the
 // new state in Terraform.
-func (r NetworkZoneResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkZoneModel) diag.Diagnostics {
+func (r NetworkZoneResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkZoneModel, forgetOnNotFound bool) diag.Diagnostics {
 	zoneName := m.Name.ValueString()
 	zone, _, err := server.GetNetworkZone(zoneName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/network/resource_network_zone_record.go
+++ b/internal/network/resource_network_zone_record.go
@@ -196,7 +196,7 @@ func (r NetworkZoneRecordResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -219,7 +219,7 @@ func (r NetworkZoneRecordResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -278,7 +278,7 @@ func (r NetworkZoneRecordResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -337,14 +337,14 @@ func (r NetworkZoneRecordResource) ImportState(ctx context.Context, req resource
 // SyncState fetches the server's current state for a network zone record and
 // updates the provided model. It then applies this updated model as the new
 // state in Terraform.
-func (r NetworkZoneRecordResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkZoneRecordModel) diag.Diagnostics {
+func (r NetworkZoneRecordResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m NetworkZoneRecordModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	zoneName := m.Zone.ValueString()
 	recordName := m.Name.ValueString()
 	record, _, err := server.GetNetworkZoneRecord(zoneName, recordName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/profile/resource_profile.go
+++ b/internal/profile/resource_profile.go
@@ -232,7 +232,7 @@ func (r ProfileResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -254,7 +254,7 @@ func (r ProfileResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -327,7 +327,7 @@ func (r ProfileResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -408,13 +408,13 @@ func (r ProfileResource) ImportState(ctx context.Context, req resource.ImportSta
 // SyncState fetches the server's current state for a profile and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r ProfileResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m ProfileModel) diag.Diagnostics {
+func (r ProfileResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m ProfileModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	profileName := m.Name.ValueString()
 	profile, _, err := server.GetProfile(profileName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/project/resource_project.go
+++ b/internal/project/resource_project.go
@@ -137,7 +137,7 @@ func (r ProjectResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -159,7 +159,7 @@ func (r ProjectResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -208,7 +208,7 @@ func (r ProjectResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -269,13 +269,13 @@ func (r *ProjectResource) ImportState(ctx context.Context, req resource.ImportSt
 // SyncState fetches the server's current state for a project and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r ProjectResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m ProjectModel) diag.Diagnostics {
+func (r ProjectResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m ProjectModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	projectName := m.Name.ValueString()
 	project, _, err := server.GetProject(projectName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/storage/resource_storage_bucket.go
+++ b/internal/storage/resource_storage_bucket.go
@@ -178,7 +178,7 @@ func (r StorageBucketResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -200,7 +200,7 @@ func (r StorageBucketResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -251,7 +251,7 @@ func (r StorageBucketResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -309,14 +309,14 @@ func (r StorageBucketResource) ImportState(ctx context.Context, req resource.Imp
 // SyncState fetches the server's current state for a storage bucket and
 // updates the provided model. It then applies this updated model as the
 // new state in Terraform.
-func (r StorageBucketResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StorageBucketModel) diag.Diagnostics {
+func (r StorageBucketResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StorageBucketModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	poolName := m.Pool.ValueString()
 	bucketName := m.Name.ValueString()
 	bucket, _, err := server.GetStoragePoolBucket(poolName, bucketName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/storage/resource_storage_bucket_key.go
+++ b/internal/storage/resource_storage_bucket_key.go
@@ -187,7 +187,7 @@ func (r StorageBucketKeyResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -208,7 +208,7 @@ func (r StorageBucketKeyResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -264,7 +264,7 @@ func (r StorageBucketKeyResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -331,7 +331,7 @@ func (r StorageBucketKeyResource) ImportState(ctx context.Context, req resource.
 // SyncState fetches the server's current state for a storage bucket key and
 // updates the provided model. It then applies this updated model as the
 // new state in Terraform.
-func (r StorageBucketKeyResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StorageBucketKeyModel) diag.Diagnostics {
+func (r StorageBucketKeyResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StorageBucketKeyModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	poolName := m.Pool.ValueString()
@@ -340,7 +340,7 @@ func (r StorageBucketKeyResource) SyncState(ctx context.Context, tfState *tfsdk.
 
 	key, _, err := server.GetStoragePoolBucketKey(poolName, bucketName, keyName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -291,7 +291,7 @@ func (r StoragePoolResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -313,7 +313,7 @@ func (r StoragePoolResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -394,7 +394,7 @@ func (r StoragePoolResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Update Terraform state.
-	diags := r.SyncState(ctx, &resp.State, server, plan)
+	diags := r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -452,13 +452,13 @@ func (r StoragePoolResource) ImportState(ctx context.Context, req resource.Impor
 // SyncState fetches the server's current state for a storage pool and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r StoragePoolResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StoragePoolModel) diag.Diagnostics {
+func (r StoragePoolResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StoragePoolModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	poolName := m.Name.ValueString()
 	pool, _, err := server.GetStoragePool(poolName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/storage/resource_storage_volume.go
+++ b/internal/storage/resource_storage_volume.go
@@ -214,7 +214,7 @@ func (r StorageVolumeResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -237,7 +237,7 @@ func (r StorageVolumeResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -294,7 +294,7 @@ func (r StorageVolumeResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -357,7 +357,7 @@ func (r StorageVolumeResource) ImportState(ctx context.Context, req resource.Imp
 // SyncState fetches the server's current state for a storage volume and
 // updates the provided model. It then applies this updated model as the
 // new state in Terraform.
-func (r StorageVolumeResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StorageVolumeModel) diag.Diagnostics {
+func (r StorageVolumeResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m StorageVolumeModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	poolName := m.Pool.ValueString()
@@ -365,7 +365,7 @@ func (r StorageVolumeResource) SyncState(ctx context.Context, tfState *tfsdk.Sta
 	volType := m.Type.ValueString()
 	vol, _, err := server.GetStoragePoolVolume(poolName, volType, volName)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}

--- a/internal/truststore/trust_certificate.go
+++ b/internal/truststore/trust_certificate.go
@@ -244,7 +244,7 @@ func (r TrustCertificateResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -265,7 +265,7 @@ func (r TrustCertificateResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, state)
+	diags = r.SyncState(ctx, &resp.State, server, state, true)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -319,7 +319,7 @@ func (r TrustCertificateResource) Update(ctx context.Context, req resource.Updat
 	plan.Fingerprint = state.Fingerprint
 
 	// Update Terraform state.
-	diags = r.SyncState(ctx, &resp.State, server, plan)
+	diags = r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -354,14 +354,14 @@ func (r TrustCertificateResource) Delete(ctx context.Context, req resource.Delet
 // SyncState fetches the server's current state for a certificate and updates
 // the provided model. It then applies this updated model as the new state
 // in Terraform.
-func (r TrustCertificateResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m TrustCertificateModel) diag.Diagnostics {
+func (r TrustCertificateResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m TrustCertificateModel, forgetOnNotFound bool) diag.Diagnostics {
 	var respDiags diag.Diagnostics
 
 	certName := m.Name.ValueString()
 	certFingerprint := m.Fingerprint.ValueString()
 	cert, _, err := server.GetCertificate(certFingerprint)
 	if err != nil {
-		if errors.IsNotFoundError(err) {
+		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
 			return nil
 		}


### PR DESCRIPTION
If resource is read and not found on the remote server (removed outside Terraform), remove its state so that Terraform considers that as missing resource and plans creation of the resource.

If resource is being created or updated and is not found afterwards, retain the state and error out. This indicates bigger underlying issue which is currently silently ignored (by state being removed) and results in Terraform panic due to missing state.